### PR TITLE
Feat: inject custom logger in options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install
         run: |
-          npm install
+          npm install --ignore-scripts
 
       - name: Run tests
         run: |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,26 @@ closeWithGrace({ delay: 500 }, async function ({ signal, err, manual }) {
 })
 ```
 
+### Injecting custom logger
+
+```js
+const closeWithGrace = require('close-with-grace')
+
+// delay is the number of milliseconds for the graceful close to
+// finish.
+closeWithGrace(
+  {
+    delay: 500,
+    logger: { error: (m) => console.error(`[close-with-grace] ${m}`) }
+  },
+  async function ({ signal, err, manual }) {
+  if (err) {
+    console.error(err)
+  }
+  await closeYourServer()
+})
+```
+
 ## API
 
 ### `closeWithGrace([opts], fn({ err, signal, manual }))`
@@ -41,6 +61,8 @@ If it is emitted again, it will terminate the process abruptly.
 
 * `delay`: the numbers of milliseconds before abruptly close the
   process. Default: `10000`.
+
+* `logger`: instance of logger which will be used internally. Default: `10000`.
 
 #### fn({ err, signal, manual } [, cb])
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,19 @@
 declare namespace closeWithGrace {
+  interface Logger {
+    error(message?: any, ...optionalParams: any[]): void
+  }
+
   interface Options {
     /**
      * The numbers of milliseconds before abruptly close the process
      * @default 10000
      */
-    delay: number
+    delay?: number
+    /**
+     * Instance of logger which will be used internally
+     * @default console
+     */
+    logger?: Logger
   }
 
   type Signals = "SIGTERM" | "SIGINT"

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ function closeWithGrace (opts, fn) {
     opts = {}
   }
   const delay = opts.delay ? opts.delay : 10000
+  const logger = opts.logger ? opts.logger : console
   process.once('SIGTERM', onSignal)
   process.once('SIGINT', onSignal)
   process.once('uncaughtException', onError)
@@ -35,7 +36,7 @@ function closeWithGrace (opts, fn) {
   }
 
   function afterFirstSignal (signal) {
-    console.error(`second ${signal}, exiting`)
+    logger.error(`second ${signal}, exiting`)
     process.exit(1)
   }
 
@@ -44,8 +45,8 @@ function closeWithGrace (opts, fn) {
   }
 
   function afterFirstError (err) {
-    console.error('second error, exiting')
-    console.error(err)
+    logger.error('second error, exiting')
+    logger.error(err)
     process.exit(1)
   }
 
@@ -102,7 +103,7 @@ function closeWithGrace (opts, fn) {
         process.exit(0)
       }
     } catch (err) {
-      console.error(err)
+      logger.error(err)
       process.exit(1)
     }
   }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -62,7 +62,10 @@ expectAssignable<CloseWithGraceCallback>(WrongCallback)
 expectAssignable<Signals>("SIGINT")
 expectAssignable<Signals>("SIGTERM")
 
-expectType<Options>({ delay: 10 })
+expectAssignable<Options>({ delay: 10 })
+expectAssignable<Options>({ logger: console })
+expectAssignable<Options>({ logger: console, delay: 10 })
+expectAssignable<Options>({ logger: { error: () => {} } })
 
 expectAssignable<{
   close: () => void

--- a/test/no-resolve-custom-logger.js
+++ b/test/no-resolve-custom-logger.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const closeWithGrace = require('..')
+
+const customLogger = {
+  error (message) {
+    console.error(`[custom logger] ${message}`)
+  }
+}
+
+closeWithGrace({ delay: 500, logger: customLogger }, function ({ signal, err }) {
+  console.log('fn called')
+  // this promise never resolves, so the delay should kick in
+  return new Promise(() => {})
+})
+
+// to keep the process open
+setInterval(() => {}, 1000)
+console.error(process.pid)


### PR DESCRIPTION
Closes #9 

Note: Originally I wanted to provide access to instance of logger in callback, but now it seems that it's not a great idea, cause then we could be confused which logs comes from lib itself and which from user 