### PR TITLE
feat: log when killed by timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,10 @@ function closeWithGrace (opts, fn) {
         exec(out)
       ])
 
-      if (res === sleeped || out.err) {
+      if (res === sleeped) {
+        if (logger) logger.error(`killed by timeout (${delay}ms)`)
+        process.exit(1)
+      } else if (out.err) {
         process.exit(1)
       } else {
         process.exit(0)


### PR DESCRIPTION
This is a draft. Please don't hesitate to let me know if any improvements needed. I'm not sure if it makes sense to give users the ability to set a custom message for the logger here.

As an idea, we could provide something like https://fastify.dev/docs/v5.0.x/Reference/Server/#listentextresolver parameter but for a timeout message

Closes #27 