### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,32 +9,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  legacy:
-    permissions:
-      contents: read
-
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [14.x, 16.x]
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Use Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: Install
-        run: |
-          npm install --ignore-scripts
-
-      - name: Run tests
-        run: |
-          npm run test-only
-
   test:
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const { signalEvents } = require('./events/signal.events')
 const { errorEvents } = require('./events/error.events')
 const { exitEvents } = require('./events/exit.events')
 
-const { promisify } = require('util')
+const { promisify } = require('node:util')
 const sleep = promisify(setTimeout)
 
 closeWithGrace.closing = false

--- a/test/close.test.js
+++ b/test/close.test.js
@@ -3,10 +3,10 @@
 const { signalEvents } = require('../events/signal.events')
 const { errorEvents } = require('../events/error.events')
 const test = require('tape')
-const { fork } = require('child_process')
-const { join } = require('path')
-const { once } = require('events')
-const { promisify } = require('util')
+const { fork } = require('node:child_process')
+const { join } = require('node:path')
+const { once } = require('node:events')
+const { promisify } = require('node:util')
 const sleep = promisify(setTimeout)
 
 async function all (stream) {

--- a/test/closing-state.js
+++ b/test/closing-state.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const closeWithGrace = require('..')
-const assert = require('assert')
+const assert = require('node:assert')
 
 assert.strictEqual(closeWithGrace.closing, false)
 const { close } = closeWithGrace(async function ({ manual }) {

--- a/test/default-delay.js
+++ b/test/default-delay.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { promisify } = require('util')
+const { promisify } = require('node:util')
 const closeWithGrace = require('..')
 
 const immediate = promisify(setImmediate)

--- a/test/self-close.js
+++ b/test/self-close.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const closeWithGrace = require('..')
-const assert = require('assert')
+const assert = require('node:assert')
 
 const { close } = closeWithGrace(async function ({ manual }) {
   assert.strictEqual(manual, true)

--- a/test/simple.js
+++ b/test/simple.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { promisify } = require('util')
+const { promisify } = require('node:util')
 const closeWithGrace = require('..')
 
 const immediate = promisify(setImmediate)


### PR DESCRIPTION
See https://github.com/nodejs/node/pull/37246/files#r588397158 and https://nodejs.org/api/modules.html#core-modules

This was added in Node v16.0.0 and v14.18.0 however, so versions prior to these need to be dropped from the CI.