### PR TITLE
chore(package): explicitly declare js module type

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.1.0",
   "description": "Exit your process, gracefully (if possible)",
   "main": "index.js",
+  "type": "commonjs",
   "devDependencies": {
     "@fastify/pre-commit": "^2.0.2",
     "standard": "^17.0.0",


### PR DESCRIPTION
[Node 21.1.0 added a flag to detect module types](https://github.com/nodejs/node/releases/tag/v21.1.0), which will probably become default in the future. Declaring the type will cause Node to skip detection on startup, reducing startup time.

Declaring the package type is also considered good practice according to https://nodejs.org/api/modules.html#enabling.