### PR TITLE
Ability of disabling errorEvents as valid signal.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ build/Release
 node_modules/
 jspm_packages/
 
+# Lock files
+package-lock.json
+
 # TypeScript v1 declaration files
 typings/
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,26 @@ closeWithGrace(async function ({ signal, err, manual }) {
 await app.listen()
 ```
 
+### Skipping specific events
+
+Skip specific events from triggering the graceful close. Note: You are responsible for handling skipped events yourself.
+
+```js
+import closeWithGrace from 'close-with-grace'
+
+// Handle errors separately
+process.on('unhandledRejection', (err) => {
+  // Your custom error handling
+})
+
+closeWithGrace(
+  { skip: ['unhandledRejection', 'uncaughtException'] },
+  async function ({ signal, err, manual }) {
+    await cleanupResources()
+  }
+)
+```
+
 ## API
 
 ### `closeWithGrace([opts], fn({ err, signal, manual }))`
@@ -103,6 +123,10 @@ If it is emitted again, it will terminate the process abruptly.
 
 * `logger`: instance of logger which will be used internally. Default: `console`.
   - Pass `false`, `null` or `undefined` to disable this feature.
+
+* `skip`: an array of event names to skip from triggering the graceful close callback. Default: `[]`.
+  - Example: `skip: ['unhandledRejection', 'uncaughtException', 'SIGTERM']`
+  - Note: You must handle skipped events yourself, otherwise they may cause the process to crash or exit unexpectedly.
 
 * `onSecondError(error)`: A callback to execute if the process throws an `uncaughtException`
   or an `unhandledRejection` while `fn` is executing.

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,10 @@ declare namespace closeWithGrace {
     error(message?: any, ...optionalParams: any[]): void
   }
 
+  type Signals = 'SIGHUP' | 'SIGINT' | 'SIGQUIT' | 'SIGILL' | 'SIGTRAP' | 'SIGABRT' | 'SIGBUS' | 'SIGFPE' | 'SIGSEGV' | 'SIGUSR2' | 'SIGTERM'
+  type ErrorEvents = 'uncaughtException' | 'unhandledRejection'
+  type ExitEvents = 'beforeExit'
+  export type AllEvents = Signals | ErrorEvents | ExitEvents
   interface Options {
     /**
      * The numbers of milliseconds before abruptly close the process
@@ -14,9 +18,12 @@ declare namespace closeWithGrace {
      * @default console
      */
     logger?: Logger | undefined | null | false
+    /**
+     * Array of event names to skip from triggering the graceful close
+     * @example ['unhandledRejection', 'uncaughtException', 'SIGTERM']
+     */
+    skip?: AllEvents[]
   }
-
-  type Signals = 'SIGHUP' | 'SIGINT' | 'SIGQUIT' | 'SIGILL' | 'SIGTRAP' | 'SIGABRT' | 'SIGBUS' | 'SIGFPE' | 'SIGSEGV' | 'SIGUSR2' | 'SIGTERM'
   interface CloseWithGraceCallback {
     (
       options: { err?: Error, signal?: Signals, manual?: boolean },

--- a/index.js
+++ b/index.js
@@ -27,9 +27,15 @@ function closeWithGrace (opts, fn) {
       ? opts.logger
       : undefined
 
-  signalEvents.forEach((event) => process.once(event, onSignal))
-  errorEvents.forEach((event) => process.once(event, onError))
-  exitEvents.forEach((event) => process.once(event, onNormalExit))
+  const skip = Array.isArray(opts.skip) ? opts.skip : []
+
+  const filteredSignalEvents = signalEvents.filter((event) => !skip.includes(event))
+  const filteredErrorEvents = errorEvents.filter((event) => !skip.includes(event))
+  const filteredExitEvents = exitEvents.filter((event) => !skip.includes(event))
+
+  filteredSignalEvents.forEach((event) => process.once(event, onSignal))
+  filteredErrorEvents.forEach((event) => process.once(event, onError))
+  filteredExitEvents.forEach((event) => process.once(event, onNormalExit))
 
   const sleeped = Symbol('sleeped')
 
@@ -39,9 +45,9 @@ function closeWithGrace (opts, fn) {
   }
 
   function cleanup () {
-    signalEvents.forEach((event) => process.removeListener(event, onSignal))
-    errorEvents.forEach((event) => process.removeListener(event, onError))
-    exitEvents.forEach((event) => process.removeListener(event, onNormalExit))
+    filteredSignalEvents.forEach((event) => process.removeListener(event, onSignal))
+    filteredErrorEvents.forEach((event) => process.removeListener(event, onError))
+    filteredExitEvents.forEach((event) => process.removeListener(event, onNormalExit))
   }
 
   function onSignal (signal) {
@@ -111,8 +117,8 @@ function closeWithGrace (opts, fn) {
   async function run (out) {
     cleanup()
 
-    signalEvents.forEach((event) => process.on(event, afterFirstSignal))
-    errorEvents.forEach((event) => process.on(event, afterFirstError))
+    filteredSignalEvents.forEach((event) => process.on(event, afterFirstSignal))
+    filteredErrorEvents.forEach((event) => process.on(event, afterFirstError))
 
     closeWithGrace.closing = true
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -75,6 +75,12 @@ expectAssignable<Options>({ logger: null, delay: null })
 expectAssignable<Options>({ logger: false, delay: false })
 expectAssignable<Options>({ logger: undefined, delay: undefined })
 expectAssignable<Options>({ logger: { error: () => {} } })
+expectAssignable<Options>({ skip: ['unhandledRejection', 'uncaughtException'] })
+expectAssignable<Options>({ skip: ['SIGTERM', 'SIGINT'] })
+expectAssignable<Options>({ skip: ['beforeExit'] })
+expectAssignable<Options>({ skip: [] })
+expectError<Options>({ skip: ['INVALID'] })
+expectAssignable<Options>({ delay: 100, logger: console, skip: ['SIGTERM'] })
 
 expectAssignable<{
   close: () => void

--- a/test/skip-multiple.js
+++ b/test/skip-multiple.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const closeWithGrace = require('..')
+
+// Handle skipped events to prevent crashes
+process.on('unhandledRejection', () => {})
+process.on('uncaughtException', () => {})
+process.on('SIGTERM', () => {})
+
+closeWithGrace({ skip: ['unhandledRejection', 'uncaughtException', 'SIGTERM'], delay: 500 }, async function ({ signal, err }) {
+  console.log('callback called')
+})
+
+// to keep the process open
+setInterval(() => {}, 1000)
+console.error(process.pid)


### PR DESCRIPTION
Closes #36

This PR implements #36 by simply filtering events based on their absence of `skip` property. It also adds a unit test covering it.